### PR TITLE
Fix router use syntax

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,6 @@
 import authRoutes from './routes/authRoutes';
 const router = express.Router();
-router.use('/api/auth , authRoutes);')
+router.use('/api/auth', authRoutes);
 import express, { type Express, Request, Response, NextFunction } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";


### PR DESCRIPTION
## Summary
- correct incorrect router.use syntax referencing `/api/auth`

## Testing
- `npm run check` *(fails: server compilation errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68491503b08483329579d8682a2e7d47