### PR TITLE
Add premium messaging features

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1247,6 +1247,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
   
   // Messages
+  // Legacy endpoint to fetch messages between two users
   app.get("/api/messages/:userId", verifyAppwriteToken, async (req, res) => {
     try {
       const userId = parseInt(req.params.userId);
@@ -1261,6 +1262,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
   
+  // Legacy send message endpoint
   app.post("/api/messages", verifyAppwriteToken, async (req, res) => {
     try {
       const messageData = req.body;
@@ -1303,6 +1305,69 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.json({ count });
     } catch (error) {
       res.status(500).json({ message: "Failed to get unread message count" });
+    }
+  });
+
+  // Premium messaging endpoints used by the client UI
+  app.get("/api/messages/:userId/:recipientId", verifyAppwriteToken, async (req, res) => {
+    try {
+      const { userId, recipientId } = req.params;
+      const messages = await storage.getPremiumMessagesByUsers(userId, recipientId);
+      res.json(messages);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch messages" });
+    }
+  });
+
+  app.post("/api/messages/send", verifyAppwriteToken, async (req, res) => {
+    try {
+      const { receiverId, content, isPaid, price } = req.body;
+      const message = await storage.createPremiumMessage({
+        senderId: req.user.id,
+        receiverId,
+        message: content,
+        isPaid: Boolean(isPaid),
+        price: price ?? null,
+      });
+      res.status(201).json(message);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to send message" });
+    }
+  });
+
+  app.post("/api/messages/mark-read", verifyAppwriteToken, async (req, res) => {
+    try {
+      const { userId, recipientId } = req.body;
+      await storage.markPremiumMessagesRead(userId, recipientId);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ message: "Failed to mark messages as read" });
+    }
+  });
+
+  app.post("/api/messages/:id/pay", verifyAppwriteToken, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id);
+      if (isNaN(id)) return res.status(400).json({ message: "Invalid message id" });
+
+      const message = await storage.payForPremiumMessage(id);
+      if (!message) return res.status(404).json({ message: "Message not found" });
+
+      // Deduct balance from payer and credit sender
+      if (message.price && message.receiverId === req.user.id) {
+        const amount = Number(message.price);
+        const payer = await storage.getUser(req.user.id);
+        const sender = await storage.getUser(message.senderId);
+        if (payer && sender) {
+          await storage.updateUser(payer.id, { accountBalance: (Number(payer.accountBalance)||0) - amount });
+          const credit = Math.floor(amount * 0.7);
+          await storage.updateUser(sender.id, { accountBalance: (Number(sender.accountBalance)||0) + credit });
+        }
+      }
+
+      res.json(message);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to process payment" });
     }
   });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -322,6 +322,9 @@ export const insertForumCommentSchema = createInsertSchema(forumComments)
 export const insertMessageSchema = createInsertSchema(messages)
   .omit({ id: true, createdAt: true, readAt: true });
 
+export const insertPremiumMessageSchema = createInsertSchema(premiumMessages)
+  .omit({ id: true, createdAt: true, isRead: true, isPaid: true });
+
 export const insertGiftSchema = createInsertSchema(gifts)
   .omit({ id: true, createdAt: true, processed: true, processedAt: true });
 
@@ -363,6 +366,9 @@ export type Message = typeof messages.$inferSelect;
 
 export type InsertGift = z.infer<typeof insertGiftSchema>;
 export type Gift = typeof gifts.$inferSelect;
+
+export type InsertPremiumMessage = z.infer<typeof insertPremiumMessageSchema>;
+export type PremiumMessage = typeof premiumMessages.$inferSelect;
 
 export type InsertReaderApplication = z.infer<typeof insertReaderApplicationSchema>;
 export type ReaderApplication = typeof readerApplications.$inferSelect;


### PR DESCRIPTION
## Summary
- expose premium message types in schema
- extend storage layer for premium messaging
- implement premium messaging API routes

## Testing
- `npm run check` *(fails: TS errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_684a05e159ec8332ab7d27e5c4c440a5

## Summary by Sourcery

Implement premium messaging functionality by extending schema, storage, and API layers to support sending, retrieving, read-status updates, and payment processing with account balance adjustments.

New Features:
- Extend shared schema with InsertPremiumMessage and PremiumMessage types and validation schema
- Add storage interface methods and database implementations for creating, fetching, marking as read, counting, and paying for premium messages
- Introduce API routes to fetch, send, mark as read, and process payments for premium messages with automated account balance updates