### PR TITLE
Implement session end notification

### DIFF
--- a/server/services/signaling.ts
+++ b/server/services/signaling.ts
@@ -314,7 +314,7 @@ function handleEndCall(socket: Socket, data: { readingId: number, userId: number
  * @param event The event name
  * @param data The event data
  */
-function broadcastToReading(readingId: number, event: string, data: any): void {
+export function broadcastToReading(readingId: number, event: string, data: any): void {
   try {
     if (!io) {
       throw new Error('Signaling service not initialized');


### PR DESCRIPTION
### **User description**
## Summary
- broadcast billing ended events when funds run out
- expose broadcast helper from signaling service

## Testing
- `npm run check` *(fails: numerous existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a06648fdc833295bf850f2a6dbae9


___

### **PR Type**
Enhancement


___

### **Description**
• Implement session end notification when billing funds run out
• Expose broadcast helper function from signaling service
• Add session data retrieval for billing ended events


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>billingService.ts</strong><dd><code>Add billing end notification with session data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/billingService.ts

• Import <code>broadcastToReading</code> from signaling service<br> • Retrieve session <br>data (total_minutes, amount_charged) after ending session<br> • Broadcast <br>'billing_ended' event with session details to all clients<br> • Replace <br>TODO comment with actual notification implementation


</details>


  </td>
  <td><a href="https://github.com/EmilynnJ/soulseer4325_2/pull/28/files#diff-0a47373bc47127f2cf53f302cf582ec6c8746881d0357970cbd79d1057d2b39a">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>signaling.ts</strong><dd><code>Export broadcast helper function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/services/signaling.ts

• Export <code>broadcastToReading</code> function to make it available to other <br>services


</details>


  </td>
  <td><a href="https://github.com/EmilynnJ/soulseer4325_2/pull/28/files#diff-05c215bf5dd2bcf32553f3f8888db0160377dc03f321e29362b8c7674c6b8d01">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users and readers will now receive a notification if a session ends due to insufficient funds, including details such as elapsed time and total cost.
- **Improvements**
  - Enhanced real-time communication for session status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->